### PR TITLE
Added exceptions to fetchClass

### DIFF
--- a/app/src/main/java/org/Controller/CLController.java
+++ b/app/src/main/java/org/Controller/CLController.java
@@ -622,7 +622,7 @@ public class CLController {
 			methodName = sc.nextLine();
 			view.show(model.listMethodArities(activeClass, methodName));
 			//int paramArity = -1;
-			view.show("How many parameters does " + input + " have?");
+			view.show("How many parameters does " + methodName + " have?");
 			boolean validArity = false;
 			while (!validArity) {
 				if (sc.hasNextInt()) {
@@ -757,7 +757,7 @@ public class CLController {
 					editor.removeParam(activeMethod, param);
 					view.show("Success! Parameter " + paramName + " has been removed.");
 				} else {
-					view.show("Error: Parameter " + paramName + " does not exist in method " + input);
+					view.show("Error: Parameter " + paramName + " does not exist in method " + methodName);
 				}
 			}
 			view.show("What parameter would you like to remove next?");
@@ -877,12 +877,11 @@ public class CLController {
 		boolean loop = true;
 		boolean changeParamReadded = false;
 		String paramName = "";
-		view.show(
-				"Type the name of a parameter you'd like to add to the new list. Type 'stop' to stop adding parameters:");
+		view.show("Type the name of a parameter you'd like to add to the new list. (enter to stop):");
 		while (loop) {
 			// Loops for adding
 			paramName = sc.nextLine().replaceAll("\\s", "");
-			if (paramName.equalsIgnoreCase("stop")) {
+			if (paramName.equalsIgnoreCase("stop") || paramName.equals("")) {
 				loop = false;
 			} else {
 				if (!input.equalsIgnoreCase("all")) {

--- a/app/src/main/java/org/Controller/CLController.java
+++ b/app/src/main/java/org/Controller/CLController.java
@@ -65,16 +65,11 @@ public class CLController {
 	private void CL_listClassInfo() {
 		try {
 			view.show(model.listClassNames());
+			view.show("What class would you like printed?");
+			input = sc.nextLine();
+			activeClass = model.fetchClass(input);
 		} catch (Exception e) {
 			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class would you like printed?");
-		input = sc.nextLine();
-		activeClass = model.fetchClass(input);
-		if (activeClass == null) {
-			// Class does not exist
-			view.show("Class " + input + " does not exist");
 			return;
 		}
 		String classInfo = model.listClassInfo(activeClass);
@@ -101,27 +96,14 @@ public class CLController {
 	 * Gets name of new class from user and displays if it was added successfully
 	 */
 	private void CL_addClass() {
-		view.show("Enter the new class' name: ");
-		input = sc.nextLine();
-		int result = model.isValidClassName(input);
-		switch (result) {
-			case 1:
-				view.show("No class name was given");
-				break;
-			case 2:
-				view.show("Name " + input + " is invalid. First character must be a letter or '_'");
-				break;
-			case 3:
-				view.show("Name " + input + " is invalid. Name can only contain alphanumerics, '_', or '$'");
-				break;
-			case 4:
-				view.show("Name " + input + " is already used by another class");
-				break;
-			case 0:
-			default:
-				editor.addClass(input);
-				view.show("Class " + input + " succesfully added");
-				break;
+		try {
+			view.show("Enter the new class' name: ");
+			input = sc.nextLine();
+			model.isValidClassName(input);
+			editor.addClass(input);
+			view.show("Class " + input + " succesfully added");
+		} catch (Exception e) {
+			view.show(e.getMessage());
 		}
 	}
 
@@ -131,16 +113,12 @@ public class CLController {
 	private void CL_deleteClass() {
 		try {
 			view.show(model.listClassNames());
+			view.show("What class would you like to delete?");
+			input = sc.nextLine();
+			editor.deleteClass(input);
+			view.show("Class " + input + " successfully deleted");
 		} catch (Exception e) {
 			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class would you like to delete?");
-		input = sc.nextLine();
-		if (editor.deleteClass(input)) {
-			view.show("Class " + input + " successfully deleted");
-		} else {
-			view.show("Class " + input + " could not be deleted");
 		}
 	}
 
@@ -150,40 +128,16 @@ public class CLController {
 	private void CL_renameClass() {
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class would you like to rename?");
-		input = sc.nextLine();
-		activeClass = model.fetchClass(input);
-		if (activeClass != null) {
-			// Class to be renamed exists
+			view.show("What class would you like to rename?");
+			input = sc.nextLine();
+			activeClass = model.fetchClass(input);
 			view.show("What would you like the new name to be?");
 			String newName = sc.nextLine();
-			int result = model.isValidClassName(newName);
-			switch (result) {
-				case 1:
-					view.show("No new class name was given");
-					break;
-				case 2:
-					view.show("Name " + newName + " is invalid. First character must be a letter or '_'");
-					break;
-				case 3:
-					view.show("Name " + newName + " is invalid. Name can only contain alphanumerics, '_', or '$'");
-					break;
-				case 4:
-					view.show("Name " + newName + " is already used by another class");
-					break;
-				case 0:
-				default:
-					editor.renameClass(activeClass, newName);
-					view.show("Class " + input + " renamed to " + newName);
-					break;
-			}
-		} else {
-			// Class to be renamed does not exist
-			view.show("Class " + input + " does not exist");
+			model.isValidClassName(newName);
+			editor.renameClass(activeClass, newName);
+			view.show("Class " + input + " renamed to " + newName);
+		} catch (Exception e) {
+			view.show(e.getMessage());
 		}
 	}
 
@@ -191,32 +145,24 @@ public class CLController {
 	 * Gets relationship info from user and returns if action succeeded or failed
 	 */
 	private void CL_addRelationship() {
+		// Temporarily move instantations to before try block so
+		// they are accessible later in function
+		String source = "";
+		String dest = "";
 		try {
 			view.show(model.listClassNames());
+			view.show("Enter the source class");
+			source = sc.nextLine();
+			model.fetchClass(source);
+			view.show(model.listClassNames());
+			view.show("Enter the destination class");
+			dest = sc.nextLine();
+			model.fetchClass(dest);
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
 
-		view.show("Enter the source class");
-		String source = sc.nextLine();
-		if (model.fetchClass(source) == null) {
-			view.show("Error: Inputted class " + source + " does not exist! Aborting.");
-			return;
-		}
-
-		try {
-			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("Enter the destination class");
-		String dest = sc.nextLine();
-		if (model.fetchClass(dest) == null) {
-			view.show("Error: Inputted class " + dest + " does not exist! Aborting.");
-			return;
-		}
 		if (model.relationshipExist(source, dest) != null) {
 			view.show("Error: A relationship already exists between " + source + " and " + dest + "! Aborting.");
 			return;
@@ -243,10 +189,14 @@ public class CLController {
 			}
 		}
 
+		try {
 		if (type != null && editor.addRelationship(source, dest, type)) {
 			view.show(type + " Relationship successfully created from " + source + " to " + dest);
 		} else {
 			view.show("Relationship could not be created");
+		}
+		} catch (Exception e) {
+			//Temp Try-Catch block
 		}
 	}
 
@@ -255,37 +205,25 @@ public class CLController {
 	 * Loops until the
 	 */
 	private void CL_editRelationship() {
+		String source = "";
+		String dest = "";
 		try {
 			view.show(model.listRelationships());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		// Because we are listing relationships listing classes after feels redundant
-		try {
+			// Because we are listing relationships listing classes after feels redundant
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What is the source of the relationship are you changing?");
-		String source = sc.nextLine();
-		if (model.fetchClass(source) == null) {
-			view.show("Error: Inputted class " + source + " does not exist! Aborting.");
-			return;
-		}
-		try {
+			view.show("What is the source of the relationship are you changing?");
+			source = sc.nextLine();
+			model.fetchClass(source);
 			view.show(model.listClassNames());
+			view.show("What is the destination of the relationship are you changing?");
+			dest = sc.nextLine();
+			model.fetchClass(dest);
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
-		view.show("What is the destination of the relationship are you changing?");
-		String dest = sc.nextLine();
-		if (model.fetchClass(dest) == null) {
-			view.show("Error: Inputted class " + dest + " does not exist! Aborting.");
-			return;
-		}
+		
+		
 		if (model.relationshipExist(source, dest) != null) {
 			view.show("What property of the relationship are you changing?\n");
 			view.show("You can edit the 'source', 'destination', or 'type' of this relationship.");
@@ -295,16 +233,13 @@ public class CLController {
 				case "source":
 					try {
 						view.show(model.listClassNames());
+						view.show("Which class do you want to name as the new source?");
+						value = sc.nextLine();
+						model.fetchClass(value);
+						// Need to check if Relationship w/ new source and current dest
+						// already exists and abort if yes
 					} catch (Exception e) {
 						view.show(e.getMessage());
-						return;
-					}
-					view.show("Which class do you want to name as the new source?");
-					value = sc.nextLine();
-					if (model.fetchClass(value) != null) {
-						view.show("Relationship's source successfully set to " + value);
-					} else {
-						view.show("Error: No class named " + value + "! Aborting.");
 						return;
 					}
 					break;
@@ -312,16 +247,13 @@ public class CLController {
 				case "destination":
 					try {
 						view.show(model.listClassNames());
+						view.show("What class do you want to name as the new destination?");
+						value = sc.nextLine();
+						model.fetchClass(value);
+						// Need to check if Relationship w/ current source and new dest
+						// already exists and abort if yes
 					} catch (Exception e) {
 						view.show(e.getMessage());
-						return;
-					}
-					view.show("What class do you want to name as the new destination?");
-					value = sc.nextLine();
-					if (model.fetchClass(value) != null) {
-						view.show("Relationship's destination successfully set to " + value);
-					} else {
-						view.show("Error: No class named " + value + "! Aborting.");
 						return;
 					}
 					break;
@@ -355,8 +287,12 @@ public class CLController {
 							+ " of a relationship right now. Aborting.");
 					break;
 			}
+			try {
 			if (value != null)
 				editor.editRelationship(source, dest, field, value);
+			} catch (Exception e) {
+				//Temp Try-Catch block
+			}
 		} else {
 			view.show("Error: Relationship between " + source + " and " + dest + " does not exist! Aborting.");
 		}
@@ -366,6 +302,8 @@ public class CLController {
 	 * Gets relationship info from user and returns if it was deleted
 	 */
 	private void CL_deleteRelationship() {
+		String source = "";
+		String dest = "";
 		try {
 			view.show(model.listRelationships());
 		} catch (Exception e) {
@@ -374,28 +312,18 @@ public class CLController {
 		}
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What is the source of the relationship are you deleting?");
-		String source = sc.nextLine();
-		if (model.fetchClass(source) == null) {
-			view.show("Error: Inputted class " + source + " does not exist! Aborting.");
-			return;
-		}
-		try {
+			view.show("What is the source of the relationship are you deleting?");
+			source = sc.nextLine();
+			model.fetchClass(source);
 			view.show(model.listClassNames());
+			view.show("What is the destination of the relationship are you deleting?");
+			dest = sc.nextLine();
+			model.fetchClass(dest);
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
-		view.show("What is the destination of the relationship are you deleting?");
-		String dest = sc.nextLine();
-		if (model.fetchClass(dest) == null) {
-			view.show("Error: Inputted class " + dest + " does not exist! Aborting.");
-			return;
-		}
+		
 		if (model.relationshipExist(source, dest) == null) {
 			view.show("Error: Relationship between " + source + " and " + dest + " does not exist! Aborting.");
 			return;
@@ -411,21 +339,17 @@ public class CLController {
 	 * Gets class and field info from user and returns if action succeeded or not
 	 */
 	private void CL_addField() {
+		String className = "";
 		try {
 			view.show(model.listClassNames());
+			view.show("What class would you like to add a field to?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
-		view.show("What class would you like to add a field to?");
-		String className = sc.nextLine();
-		// Error throw will be added to fetchClass later
-		activeClass = model.fetchClass(className);
-		if (activeClass == null) {
-			// Class does not exist
-			view.show("Class " + className + " does not exist");
-			return;
-		}
+		
 		view.show("What do you want to name the field?");
 		input = sc.nextLine();
 		// Duplication check will be done in addField method later
@@ -442,26 +366,18 @@ public class CLController {
 	 * Gets class and field info from user and returns if deletion succeeded
 	 */
 	private void CL_deleteField() {
+		String className = "";
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class would you like to delete a field from?");
-		String className = sc.nextLine();
-		activeClass = model.fetchClass(className);
-		if (activeClass == null) {
-			// Class does not exist
-			view.show("Class " + className + " does not exist");
-			return;
-		}
-		try {
+			view.show("What class would you like to delete a field from?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 			view.show(model.listFields(activeClass));
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
+		
 		view.show("What is the name of the field you want to delete?");
 		input = sc.nextLine();
 		AttributeInterface delField = activeClass.fetchField(input);
@@ -480,26 +396,18 @@ public class CLController {
 	 * Returns whether or not the operation succeeds
 	 */
 	private void CL_renameField() {
+		String className = "";
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class do you want to rename a field from?");
-		String className = sc.nextLine();
-		activeClass = model.fetchClass(className);
-		if (activeClass == null) {
-			// Class does not exist
-			view.show("Class " + className + " does not exist");
-			return;
-		}
-		try {
+			view.show("What class do you want to rename a field from?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 			view.show(model.listFields(activeClass));
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
+		
 		view.show("What is the name of the field you want to rename?");
 		input = sc.nextLine();
 		AttributeInterface renameField = activeClass.fetchField(input);
@@ -525,20 +433,17 @@ public class CLController {
 	 * or not
 	 */
 	private void CL_addMethod() {
+		String className = "";
 		try {
 			view.show(model.listClassNames());
+			view.show("What class would you like to add a method to?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
-		view.show("What class would you like to add a method to?");
-		String className = sc.nextLine();
-		activeClass = model.fetchClass(className);
-		if (activeClass == null) {
-			// Class does not exist
-			view.show("Class " + className + " does not exist");
-			return;
-		}
+		
 		// Class exists, get Method name and params
 		view.show("What do you want to name the method?");
 		input = sc.nextLine();
@@ -597,54 +502,39 @@ public class CLController {
 	 * Gets class and method info from user and returns if deletion succeeded
 	 */
 	private void CL_deleteMethod() {
+		String className = "";
+		int paramArity = -1;
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class would you like to delete a method from?");
-		String className = sc.nextLine();
-		activeClass = model.fetchClass(className);
-		if (activeClass == null) {
-			// Class does not exist
-			view.show("Class " + className + " does not exist");
-			return;
-		}
-		try {
+			view.show("What class would you like to delete a method from?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 			view.show(model.listMethods(activeClass));
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What is the name of the method you want to delete?");
-		input = sc.nextLine();
-		try {
+			view.show("What is the name of the method you want to delete?");
+			input = sc.nextLine();
 			view.show(model.listMethodArities(activeClass, input));
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		int paramArity = -1;
-		view.show("How many parameters does " + input + " have?");
-		boolean validArity = false;
-		while (!validArity) {
-			if (sc.hasNextInt()) {
-				paramArity = sc.nextInt();
-				if (paramArity < 0) {
-					view.show("Parameter arity must be non-negative.");
-					return;
+			//int paramArity = -1;
+			view.show("How many parameters does " + input + " have?");
+			boolean validArity = false;
+			while (!validArity) {
+				if (sc.hasNextInt()) {
+					paramArity = sc.nextInt();
+					try {
+						validArity = model.arityValid(paramArity);
+					} catch (Exception e) {
+						view.show(e.getMessage());
+					}
+				} else {
+					view.show("Invalid input. Please enter a positive number");
 				}
-				// Consume newLine char left by nextInt
-				sc.nextLine();
-				validArity = true;
-			} else {
 				// Clear invalid input from buffer
 				sc.nextLine();
-				view.show("Invalid input. Please enter a number:");
-				paramArity = sc.nextInt();
 			}
+		} catch (Exception e) {
+			view.show(e.getMessage());
+			return;
 		}
+		
 		Method delMethod = activeClass.fetchMethod(input, paramArity);
 		if (delMethod != null) {
 			// The method specified exists
@@ -661,52 +551,39 @@ public class CLController {
 	 * to Returns whether or not the operation succeeds
 	 */
 	private void CL_renameMethod() {
+		String className = "";
+		int paramArity = -1;
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class do you want to rename a method from?");
-		String className = sc.nextLine();
-		activeClass = model.fetchClass(className);
-		if (activeClass == null) {
-			// Class does not exist
-			view.show("Class " + className + " does not exist");
-			return;
-		}
-		try {
+			view.show("What class do you want to rename a method from?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 			view.show(model.listMethods(activeClass));
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What is the name of the method you want to rename?");
-		input = sc.nextLine();
-		try {
+			view.show("What is the name of the method you want to rename?");
+			input = sc.nextLine();
 			view.show(model.listMethodArities(activeClass, input));
+			//int paramArity = -1;
+			view.show("How many parameters does " + input + " have?");
+			boolean validArity = false;
+			while (!validArity) {
+				if (sc.hasNextInt()) {
+					paramArity = sc.nextInt();
+					try {
+						validArity = model.arityValid(paramArity);
+					} catch (Exception e) {
+						view.show(e.getMessage());
+					}
+				} else {
+					view.show("Invalid input. Please enter a positive number");
+				}
+				// Clear invalid input from buffer
+				sc.nextLine();
+			}
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
-		int paramArity = -1;
-		view.show("How many parameters does " + input + " have?");
-		if (sc.hasNextInt()) {
-			paramArity = sc.nextInt();
-			if (paramArity < 0) {
-				view.show("Parameter arity must be non-negative");
-				// Consume newLine char left by nextInt
-				sc.nextLine();
-				return;
-			}
-			// Consume newLine char left by nextInt
-			sc.nextLine();
-		} else {
-			view.show("Invalid input. Please enter a number");
-			// Clear invalid input from buffer
-			sc.nextLine();
-			return;
-		}
+		
 		Method renameMethod = activeClass.fetchMethod(input, paramArity);
 		if (renameMethod != null) {
 			// The method does exist
@@ -732,53 +609,40 @@ public class CLController {
 	 * to the list of parameters attached to the method.
 	 */
 	private void CL_addParam() {
+		String className = "";
+		String methodName = "";
+		int paramArity = -1;
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class does the method you want to add the parameter to belong to?");
-		String className = sc.nextLine();
-		ClassObject activeClass = model.fetchClass(className);
-
-		if (activeClass == null) {
-			// class doesn't exist
-			view.show("Class not here :(");
-			return;
-		}
-
-		// The class exists
-		try {
+			view.show("What class does the method you want to add the parameter to belong to?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 			view.show(model.listMethods(activeClass));
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("Please type the name of the method you'd like to add parameters to:");
-		String methodName = sc.nextLine();
-		try {
+			view.show("Please type the name of the method you'd like to add parameters to:");
+			methodName = sc.nextLine();
 			view.show(model.listMethodArities(activeClass, methodName));
+			//int paramArity = -1;
+			view.show("How many parameters does " + input + " have?");
+			boolean validArity = false;
+			while (!validArity) {
+				if (sc.hasNextInt()) {
+					paramArity = sc.nextInt();
+					try {
+						validArity = model.arityValid(paramArity);
+					} catch (Exception e) {
+						view.show(e.getMessage());
+					}
+				} else {
+					view.show("Invalid input. Please enter a positive number");
+				}
+				// Clear invalid input from buffer
+				sc.nextLine();
+			}
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
-		int paramArity = -1;
-		view.show("How many parameters does " + methodName + " have?");
-		if (sc.hasNextInt()) {
-			paramArity = sc.nextInt();
-			if (paramArity < 0) {
-				view.show("Parameter arity must be non-negative");
-				return;
-			}
-			// Consume newLine char left by nextInt
-			sc.nextLine();
-		} else {
-			view.show("Invalid input. Please enter a number");
-			// Clear invalid input from buffer
-			sc.nextLine();
-			return;
-		}
+
 		Method attr = activeClass.fetchMethod(methodName, paramArity);
 		if (attr == null) {
 			view.show("no Method by this name exists");
@@ -824,48 +688,41 @@ public class CLController {
 	 * the named parameter.
 	 */
 	private void CL_removeParam() {
+		String className = "";
+		String methodName = "";
+		int paramArity = -1;
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class does the method you want to remove the parameter from belong to?");
-		String className = sc.nextLine();
-		ClassObject activeClass = model.fetchClass(className);
-		if (activeClass == null) {
-			// class doesn't exist
-			view.show("The class " + className + " does not exist.");
-			return;
-		}
-		try {
+			view.show("What class does the method you want to remove the parameter from belong to?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 			view.show(model.listMethods(activeClass));
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("Please type the name of the method you'd like to remove parameter(s) from: ");
-		String methodName = sc.nextLine();
-		int paramArity = -1;
-		view.show("How many parameters does " + methodName + " have?");
-		boolean validArity = false;
-		while (!validArity) {
-			validArity = sc.hasNextInt();
-			if (validArity) {
-				paramArity = sc.nextInt();
-				if (paramArity < 0) {
-					view.show("Parameter arity must be non-negative.");
-					return;
+			view.show("Please type the name of the method you'd like to remove parameter(s) from: ");
+			methodName = sc.nextLine();
+			view.show(model.listMethodArities(activeClass, methodName));
+			//int paramArity = -1;
+			view.show("How many parameters does " + methodName + " have?");
+			boolean validArity = false;
+			while (!validArity) {
+				if (sc.hasNextInt()) {
+					paramArity = sc.nextInt();
+					try {
+						validArity = model.arityValid(paramArity);
+					} catch (Exception e) {
+						view.show(e.getMessage());
+					}
+				} else {
+					view.show("Invalid input. Please enter a positive number");
 				}
-				// Consume newLine char left by nextInt
-				sc.nextLine();
-			} else {
-
 				// Clear invalid input from buffer
 				sc.nextLine();
-				view.show("Invalid input. Please enter a number:");
 			}
+		} catch (Exception e) {
+			view.show(e.getMessage());
+			return;
 		}
+		
+
 		Method attr = activeClass.fetchMethod(methodName, paramArity);
 
 		if (attr == null) {
@@ -910,50 +767,41 @@ public class CLController {
 	}
 
 	private void CL_removeAllParam() {
+		String className = "";
+		String methodName = "";
+		int paramArity = -1;
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class does the method you want to remove the parameter from belong to?");
-		String className = sc.nextLine();
-		ClassObject activeClass = model.fetchClass(className);
-		if (activeClass == null) {
-			// class doesn't exist
-			view.show("The class " + className + " does not exist.");
-			return;
-		}
-		// The class exists
-		try {
+			view.show("What class does the method you want to remove the parameter from belong to?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 			view.show(model.listMethods(activeClass));
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("Please type the name of the method you'd like to remove parameter(s) from: ");
-		String methodName = sc.nextLine();
-		int paramArity = -1;
-		view.show("How many parameters does " + methodName + " have?");
-		boolean validArity = false;
-		while (!validArity) {
-			if (sc.hasNextInt()) {
-				paramArity = sc.nextInt();
-				if (paramArity < 0) {
-					view.show("Parameter arity must be non-negative.");
-					return;
+			view.show("Please type the name of the method you'd like to remove parameter(s) from: ");
+			methodName = sc.nextLine();
+			view.show(model.listMethodArities(activeClass, methodName));
+			//int paramArity = -1;
+			view.show("How many parameters does " + methodName + " have?");
+			boolean validArity = false;
+			while (!validArity) {
+				if (sc.hasNextInt()) {
+					paramArity = sc.nextInt();
+					try {
+						validArity = model.arityValid(paramArity);
+					} catch (Exception e) {
+						view.show(e.getMessage());
+					}
+				} else {
+					view.show("Invalid input. Please enter a positive number");
 				}
-				// Consume newLine char left by nextInt
-				sc.nextLine();
-				validArity = true;
-			} else {
-
 				// Clear invalid input from buffer
 				sc.nextLine();
-				view.show("Invalid input. Please enter a number:");
-				paramArity = sc.nextInt();
 			}
+		} catch (Exception e) {
+			view.show(e.getMessage());
+			return;
 		}
+		
+		
 		Method attr = activeClass.fetchMethod(methodName, paramArity);
 
 		if (attr == null) {
@@ -967,59 +815,47 @@ public class CLController {
 	}
 
 	/*
-	 * Gets the class, and method that the parameters belongs to and asks the user
-	 * if they'd like to change
-	 * one or all of the parameters. If its all parameters it replaces everything
-	 * after index 0 with a new list.
-	 * if its one parameter it replaces everything after the parameter to be changed
-	 * with a new list of parameters
-	 * containing all of the new parameters as well as the old parameters at their
-	 * locations prior to the change.
+	 * Gets the class, and method that the parameters belongs to and asks the user if they'd like to change
+	 * one or all of the parameters. If its all parameters it replaces everything after index 0 with a new list.
+	 * if its one parameter it replaces everything after the parameter to be changed with a new list of parameters
+	 * containing all of the new parameters as well as the old parameters at their locations prior to the change.
 	 */
 	private void CL_changeParam() {
+		String className = "";
+		String methodName = "";
+		int paramArity = -1;
 		try {
 			view.show(model.listClassNames());
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("What class does the method you want to add the parameter to belong to?");
-		String className = sc.nextLine();
-		ClassObject activeClass = model.fetchClass(className);
-		if (activeClass == null) {
-			view.show("Class not here :(");
-			return;
-		}
-		try {
+			view.show("What class does the method you want to add the parameter to belong to?");
+			className = sc.nextLine();
+			activeClass = model.fetchClass(className);
 			view.show(model.listMethods(activeClass));
-		} catch (Exception e) {
-			view.show(e.getMessage());
-			return;
-		}
-		view.show("Please type the name of the method you'd like to add parameters to:");
-		String methodName = sc.nextLine();
-		try {
+			view.show("Please type the name of the method you'd like to add parameters to:");
+			methodName = sc.nextLine();
 			view.show(model.listMethodArities(activeClass, methodName));
+			//int paramArity = -1;
+			view.show("How many parameters does " + methodName + " have?");
+			boolean validArity = false;
+			while (!validArity) {
+				if (sc.hasNextInt()) {
+					paramArity = sc.nextInt();
+					try {
+						validArity = model.arityValid(paramArity);
+					} catch (Exception e) {
+						view.show(e.getMessage());
+					}
+				} else {
+					view.show("Invalid input. Please enter a positive number");
+				}
+				// Clear invalid input from buffer
+				sc.nextLine();
+			}
 		} catch (Exception e) {
 			view.show(e.getMessage());
 			return;
 		}
-		int paramArity = -1;
-		view.show("How many parameters does " + methodName + " have?");
-		if (sc.hasNextInt()) {
-			paramArity = sc.nextInt();
-			if (paramArity < 0) {
-				view.show("Parameter arity must be non-negative");
-				return;
-			}
-			// Consume newLine char left by nextInt
-			sc.nextLine();
-		} else {
-			view.show("Invalid input. Please enter a number");
-			// Clear invalid input from buffer
-			sc.nextLine();
-			return;
-		}
+
+
 		Method attr = activeClass.fetchMethod(methodName, paramArity);
 		if (attr == null) {
 			view.show("method not here");
@@ -1028,8 +864,7 @@ public class CLController {
 
 		// The method exists
 		Method activeMethod = (Method) attr;
-		view.show(
-				"Type 'All' to replace all of the parameters or type the name of the parameter you'd like to replace:");
+		view.show("Type 'All' to replace all of the parameters or type the name of the parameter you'd like to replace:");
 		input = sc.nextLine().replaceAll("//s", "");
 		Parameter oldParam = activeMethod.fetchParameter(input);
 		if (!input.equalsIgnoreCase("all") && oldParam == null) {

--- a/app/src/main/java/org/Controller/GUIController.java
+++ b/app/src/main/java/org/Controller/GUIController.java
@@ -105,13 +105,17 @@ public class GUIController {
     private void promptForClassName() {
         String className = JOptionPane.showInputDialog(view, "Enter Class Name:", "New Class", JOptionPane.PLAIN_MESSAGE);
 
-        if (model.isValidClassName(className)!=0) return; //replace with switch for more specific error messages
-
-        className = className.trim();
+        //if (model.isValidClassName(className)!=0) return; replace with switch for more specific error messages
+        try {
+            model.isValidClassName(className);
+            className = className.trim();
         
-        editor.addClass(className);
-        activeClass = model.fetchClass(className);
-        addClass(activeClass);
+            editor.addClass(className);
+            activeClass = model.fetchClass(className);
+            addClass(activeClass);  
+        } catch (Exception e) {
+            view.displayErrorMessage(e.getMessage());
+        }
     }
 
 
@@ -212,7 +216,13 @@ public class GUIController {
 
         // Remove from panel
         view.getDrawingPanel().remove(selectedClassBox);
-	editor.deleteClass(selectedClassBox.getClassName());
+        try {
+            editor.deleteClass(selectedClassBox.getClassName());
+        } catch (Exception e) {
+            view.displayErrorMessage(e.getMessage());
+            return;
+        }
+	
         classBoxes.remove(selectedClassBox);
         removeRelationships(selectedClassBox);
 
@@ -276,7 +286,13 @@ public class GUIController {
 
         GUIRelationship relationship = new GUIRelationship(source, destination, type);
         relationships.add(relationship);
-	editor.addRelationship(selectedSource.getClassName(), selectedDestination.getClassName(),relationshipTypeToEnum(type));
+        try {
+            editor.addRelationship(selectedSource.getClassName(), selectedDestination.getClassName(),relationshipTypeToEnum(type));
+        } catch (Exception e) {
+            view.displayErrorMessage(e.getMessage());
+            return;
+        }
+	
 
         view.getDrawingPanel().addRelationship(source, destination, type);
         resetRelationshipSelection();
@@ -359,7 +375,13 @@ public class GUIController {
     // Create an updated relationship
     GUIRelationship updatedRel = new GUIRelationship(newSource, newDestination, newType);
     relationships.add(updatedRel);
-    editor.addRelationship(newSource.getClassName(), newDestination.getClassName(), relationshipTypeToEnum(newType));
+    try {
+        editor.addRelationship(newSource.getClassName(), newDestination.getClassName(), relationshipTypeToEnum(newType));
+    } catch (Exception e) {
+        view.displayErrorMessage(e.getMessage());
+        return;
+    }
+    
     view.getDrawingPanel().addRelationship(newSource, newDestination, newType);
     view.getDrawingPanel().repaint();
     }

--- a/app/src/main/java/org/Controller/UMLEditor.java
+++ b/app/src/main/java/org/Controller/UMLEditor.java
@@ -52,7 +52,7 @@ public class UMLEditor {
 	 * @param className | Name of class to be deleted
 	 * @return True if operation succeeded, false otherwise
 	 */
-	public boolean deleteClass(String className) {
+	public boolean deleteClass(String className) throws Exception{
 		activeClass = model.fetchClass(className);
 		if (activeClass != null) {
 			// Class exists
@@ -99,7 +99,7 @@ public class UMLEditor {
 	 * @param newRel | Relationship to be added to relationshipList
 	 * @return True if operation succeeded, false otherwise
 	 */
-	public boolean addRelationship(String source, String dest, Type type) {
+	public boolean addRelationship(String source, String dest, Type type) throws Exception{
 		ClassObject sourceClass = model.fetchClass(source);
 		if (source != null) {
 			// Source class does exist
@@ -138,7 +138,7 @@ public class UMLEditor {
 		return false;
 	}
 
-	public void editRelationship(String source, String dest, String fieldToUpdate, String newValue){
+	public void editRelationship(String source, String dest, String fieldToUpdate, String newValue) throws Exception{
 		Relationship relExist = model.relationshipExist(source, dest);
 		if (fieldToUpdate.equals("source")){
 			if(model.fetchClass(newValue)!=null)

--- a/app/src/main/java/org/Model/UMLModel.java
+++ b/app/src/main/java/org/Model/UMLModel.java
@@ -41,8 +41,9 @@ public class UMLModel implements UMLModelInterface{
      * @param className		| The name of the class to return
      * @return ClassObject with specified name if it exists
      * 		   returns null if class does not exist
+	 * @throws Exception
      */
-    public ClassObject fetchClass(String className) {
+    public ClassObject fetchClass(String className) throws Exception {
         int index = 0;
         // Iterate through the array of classes
         while (index < classList.size()) {
@@ -53,9 +54,22 @@ public class UMLModel implements UMLModelInterface{
             }
             index++;
         }
-        // Class with className did not exist, return false
-        return null;
+        throw new Exception("Class " + className + " does not exist");
     }
+
+	/**
+	 * Checks if a class name is currently in use
+	 * @param className	| The name being checked
+	 * @return True if a class by the given name exists, false otherwise
+	 */
+	public boolean classNameUsed(String className) {
+		try {
+			fetchClass(className);
+		} catch (Exception e) {
+			return false;
+		}
+		return true;
+	}
     
     /**
      * Checks if a relationships exists
@@ -181,6 +195,7 @@ public class UMLModel implements UMLModelInterface{
 	/**
 	 * Lists all created relationships
 	 * @return A string containing a list of all relationships
+	 * @throws Exception
 	 */
     public String listRelationships() throws Exception {
 		if (relationshipList.size() == 0) {
@@ -202,6 +217,7 @@ public class UMLModel implements UMLModelInterface{
     /**
      * Creates a list of all created class names that user can reference
      * @return List of class names
+	 * @throws Exception
      */
     public String listClassNames() throws Exception {
     	if (classList.size() == 0) {
@@ -231,6 +247,7 @@ public class UMLModel implements UMLModelInterface{
      * 
      * @param cls	| Class whose fields are being listed
      * @return A string of all fields in the class
+	 * @throws Exception
      */
     public String listFields(ClassObject cls) throws Exception{
     	ArrayList<AttributeInterface> fieldList = cls.getFieldList();
@@ -261,6 +278,7 @@ public class UMLModel implements UMLModelInterface{
      * 
      * @param cls	| Class whose methods are being listed
      * @return A string containing all methods in the class
+	 * @throws Exception
      */
     public String listMethods(ClassObject cls) throws Exception{
     	ArrayList<AttributeInterface> methodList = cls.getMethodList();
@@ -297,6 +315,14 @@ public class UMLModel implements UMLModelInterface{
 		return str = str + ")";
 	}
 
+	/**
+	 * Checks if method with methodName exists
+	 * If yes, list the arities of any methods with methodName
+	 * @param cls			| The class being checked for methods with methodName
+	 * @param methodName	| The name of methods being looked for
+	 * @return String that lists arities of any methods with the given name
+	 * @throws Exception
+	 */
 	public String listMethodArities(ClassObject cls, String methodName) throws Exception {
 		// Get all methods with the same name
 		ArrayList<Method> methodList = cls.fetchMethodByName(methodName);
@@ -320,32 +346,37 @@ public class UMLModel implements UMLModelInterface{
 	 *  4. Class w/ ClassName already exists
 	 * 
 	 * @param className | The class name to be validated
-	 * @return 0 on success, 1-3 on fail
+	 * @throws Exception
 	 */
-	public int isValidClassName(String className) {
+	public void isValidClassName(String className) throws Exception{
 		// Check if the className is null or an empty string.
 		if (className == null || className.isEmpty()) {
-			return 1;
+			throw new Exception ("No class name was given");
 		}
 
 		// Verify that the first character is valid: this can be a letter or underscore
 		if (!Character.isLetter(className.charAt(0)) && className.charAt(0) != '_') {
-			return 2;
+			throw new Exception ("Name " + className + " is invalid. First character must be a letter or '_'");
 		}
 
 		// Verify that the characters are alphanumerics, underscores, or dollar signs
 		for (int i = 0; i < className.length(); i++) {
 			if (!Character.isLetterOrDigit(className.charAt(i)) && className.charAt(i) != '_') {
-				return 3;
+				throw new Exception ("Name " + className + " is invalid. Name can only contain alphanumerics, '_', or '$'");
 			}
 		}
 
 		// Check if class w/ className already exists
-		if (fetchClass(className) != null) {
-			return 4;
+		if (classNameUsed(className)) {
+			throw new Exception ("Name " + className + " is already used by another class");
 		}
+	}
 
-		// The className passed all checks and will be declared valid
-		return 0;
+	public boolean arityValid(int arity) throws Exception {
+		if (arity < 0) {
+			throw new Exception ("Arity must be non-negative");
+		} else {
+			return true;
+		}
 	}
 }

--- a/app/src/main/java/org/Model/UMLModelInterface.java
+++ b/app/src/main/java/org/Model/UMLModelInterface.java
@@ -20,7 +20,7 @@ public interface UMLModelInterface {
     * @return relationshipLength
     */
 
-    public ClassObject fetchClass(String className);
+    public ClassObject fetchClass(String className) throws Exception;
     
     /**
     * Checks if a relationships exists

--- a/app/src/test/java/org/FileManagerTest.java
+++ b/app/src/test/java/org/FileManagerTest.java
@@ -136,9 +136,10 @@ class FileManagerLoadTest {
 		edit.addClass("a");
 		edit.addClass("b");
 		edit.addClass("c");
-		edit.addRelationship("a", "b", Type.COMPOSITION);
+		
 
 		try (FileWriter writer = new FileWriter(PATH)) {
+			edit.addRelationship("a", "b", Type.COMPOSITION);
 			writer.write(CONTENT);
 		} catch (Exception e) {
 		}

--- a/app/src/test/java/org/Model/FieldTest.java
+++ b/app/src/test/java/org/Model/FieldTest.java
@@ -18,13 +18,20 @@ public class FieldTest {
 
     @BeforeEach
     public void populateClasses() {
-        testEditor.addClass("class1");
-        class1 = testModel.fetchClass("class1");
+        try {
+            testEditor.addClass("class1");
+            class1 = testModel.fetchClass("class1");
+        } catch (Exception e) {
+        }
+       
     }
 
     @AfterEach
     public void cleanUp() {
-        testEditor.deleteClass("class1");
+        try {
+            testEditor.deleteClass("class1");
+        } catch (Exception e) {
+        }
     }
 
     @Test

--- a/app/src/test/java/org/Model/MethodTest.java
+++ b/app/src/test/java/org/Model/MethodTest.java
@@ -21,14 +21,21 @@ public class MethodTest {
 
     @BeforeEach
     public void populateClasses() {
-        testEditor.addClass("class1");
-        class1 = testModel.fetchClass("class1");
-        emptyConstructList = new ArrayList<>();
+        try {
+            testEditor.addClass("class1");
+            class1 = testModel.fetchClass("class1");
+            emptyConstructList = new ArrayList<>();
+        } catch (Exception e) {
+        }
+        
     }
 
     @AfterEach
     public void cleanUp() {
-        testEditor.deleteClass("class1");
+        try {
+            testEditor.deleteClass("class1");
+        } catch (Exception e) {
+        }
     }
 
     @Test

--- a/app/src/test/java/org/classTest.java
+++ b/app/src/test/java/org/classTest.java
@@ -16,10 +16,13 @@ public class classTest {
 	ClassObject class2;
 	
 	public void populateClass() {
-		testEditor.addClass("class1");
-		class1 = testModel.fetchClass("class1");
-		testEditor.addClass("2class");
-		class2 = testModel.fetchClass("2class");
+		try {
+			testEditor.addClass("class1");
+			class1 = testModel.fetchClass("class1");
+			testEditor.addClass("2class");
+			class2 = testModel.fetchClass("2class");
+		} catch (Exception e) {
+		}
 	}
 
 	public void getName() {

--- a/app/src/test/java/org/relationshipTest.java
+++ b/app/src/test/java/org/relationshipTest.java
@@ -1,8 +1,12 @@
 package org;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.Model.UMLModel;
+import org.Model.ClassObject;
 import org.Model.Relationship;
 import org.Model.Relationship.Type;
 import org.Controller.UMLEditor;
@@ -10,36 +14,48 @@ import org.Controller.UMLEditor;
 public class relationshipTest {
 	UMLModel testModel = new UMLModel();
 	UMLEditor testEditor = new UMLEditor(testModel);
+	ClassObject class1;
+	ClassObject class2;
+	Relationship rel;
 	
+	@BeforeEach
 	public void populateClasses() {
-		testEditor.addClass("class1");
-    	testEditor.addClass("class2");
+		try {
+			testEditor.addClass("class1");
+    		testEditor.addClass("class2");
+			class1 = testModel.fetchClass("class1");
+			class2 = testModel.fetchClass("class2");
+			testEditor.addRelationship("class1", "class2", Type.REALIZATION);
+    		rel = testModel.relationshipExist("class1", "class2");
+		} catch (Exception e) {
+		}
+	}
+
+	@AfterEach
+	public void cleanUp() {
+		try {
+			testEditor.deleteClass("class1");
+			testEditor.deleteClass("class2");
+		} catch (Exception e) {
+		}
 	}
 	
+	@Test
     public void getSource(){
-    	populateClasses();
-    	testEditor.addRelationship("class1", "class2", Type.REALIZATION);
-    	Relationship rel = testModel.relationshipExist("class1", "class2");
 		
-		assertEquals(rel.getSource(), testModel.fetchClass("class1"), "source should equal to 'class1' ");
+		assertEquals(rel.getSource(), class1, "source should equal to 'class1' ");
     }
     
+	@Test
     public void getDestination(){
-    	populateClasses();
-    	testEditor.addRelationship("class1", "class2", Type.REALIZATION);
-    	Relationship rel = testModel.relationshipExist("class1", "class2");
-	
-    	
-    	assertEquals(rel.getDestination(), testModel.fetchClass("class2"), "destination should be equal to 'class2' ");
+    	assertEquals(rel.getDestination(), class2, "destination should be equal to 'class2' ");
     	
     }
     
+	@Test
     public void getID(){
-    	populateClasses();
-    	testEditor.addRelationship("class1", "class2", Type.REALIZATION);
-    	Relationship rel = testModel.relationshipExist("class1", "class2");
-    	int class1Hash = testModel.fetchClass("class1").hashCode();
-    	int class2Hash = testModel.fetchClass("class2").hashCode();
+    	int class1Hash = class1.hashCode();
+    	int class2Hash = class2.hashCode();
     	
     	assertEquals(rel.getID(),class1Hash + class2Hash ,"Should return the same value");
     }


### PR DESCRIPTION
1. Added exception to fetch class if no class with given name exists
2. Also created a function that will return false if fetchClass throws an error, for ease of use in if-statements
3. Updated controller and consolidated most of the try blocks from last pull request
4. isValidClassName throws an exception for each different case
5. When getting parameter arity from user to get a method, it does not abort when the user gives a negative number or non-int anymore
6. Updated tests to handle fetchClass, addRelationship, deleteClass, and editRelationship throwing exceptions

Other Notes:
1. Variables needed to be instantiated outside of the try block so they could be referenced later, will be fixed when entire refactor is done
2. addRelationship and editRelationship currently throw an exception b/c they use fetchClass. Could be fixed by either passing a classes in as params instead of strings or encasing it in a try-catch block. This would let us get rid of the try-catch blocks I put around these functions in the controllers and tests
3. I don't think there is currently a check when changing a relationship's source/dest to see if a relationship with the new source and dest pair already exists