### PR TITLE
Removed shorthand commands from completion

### DIFF
--- a/app/src/main/java/org/Controller/CLController.java
+++ b/app/src/main/java/org/Controller/CLController.java
@@ -159,15 +159,19 @@ public class CLController {
 				Type type = null;
 				switch(relType.toLowerCase()) {
 					case "aggregation":
+					case "a":
 						type = Type.AGGREGATION;
 						break;
 					case "composition":
+					case "c":
 						type = Type.COMPOSITION;
 						break;
 					case "inheritance":
+					case "i":
 						type = Type.INHERITANCE;
 						break;
 					case "realization":
+					case "r":
 						type = Type.REALIZATION;
 						break;
 					default:
@@ -232,15 +236,19 @@ public class CLController {
 					case "type":
 						switch(newValue.toLowerCase()) {
 							case "aggregation":
+							case "a":
 								newValue = "AGGREGATION";
 								break;
 							case "composition":
+							case "c":
 								newValue = "COMPOSITION";
 								break;
 							case "inheritance":
+							case "i":
 								newValue = "INHERITANCE";
 								break;
 							case "realization":
+							case "r":
 								newValue = "REALIZATION";
 								break;
 							default:

--- a/app/src/main/java/org/Controller/UMLCompleter.java
+++ b/app/src/main/java/org/Controller/UMLCompleter.java
@@ -79,14 +79,15 @@ public class UMLCompleter implements Completer {
         List<CharSequence> cs = new ArrayList<CharSequence>();
         if (words[0].trim().equalsIgnoreCase("help")) {
             for (int i = 0; i < classCommands.size(); i++) {
+                if (classCommands.get(i).length() < 4) {
+                    // Skip any shorthand commands
+                    continue;
+                }
                 candidates.add(new Candidate(classCommands.get(i)));
             }
             candidates.add(new Candidate("listclasses"));
-            candidates.add(new Candidate("lcs"));
             candidates.add(new Candidate("listrelationships"));
-            candidates.add(new Candidate("lr"));
             candidates.add(new Candidate("addclass"));
-            candidates.add(new Candidate("ac"));
             candidates.add(new Candidate("save"));
             candidates.add(new Candidate("saveimg"));
             candidates.add(new Candidate("load"));
@@ -97,6 +98,10 @@ public class UMLCompleter implements Completer {
             cs.add("exit");
             AutoComplete.complete(spec, words, line.wordIndex(), 0, line.cursor(), cs);
             for (CharSequence c : cs) {
+                if (c.length() < 4) {
+                    // Skip any shorthand commands
+                    continue;
+                }
                 candidates.add(new Candidate((String) c));
             }
         }


### PR DESCRIPTION
Added a check when adding command candidates to skip any that are less than four characters
Relationship types can now be denoted by their first letter or fully typing it out